### PR TITLE
Skip build

### DIFF
--- a/.ci/build.config
+++ b/.ci/build.config
@@ -1,5 +1,6 @@
 BUILD_OS="darwin,linux,windows"
 BUILD_ARCH="amd64,arm64,arm"
+SKIP_BUILD="windows-arm,windows-arm64"
 GOLANG_PACKAGE="example"
 GOLANG_VERSION_PKG="internal/version"
 GOLANG_BINARY_NAME="example"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,34 @@ A bash script used to build a go binary with some configuration options
 
 ## Usage
 
-### Show help
+### Build your binary
+```
+./bin/build
+```
+
+### Build and package your binaries for release
+```
+./bin/build --all --package
+```
+
+### Display help options
 ```
 ./bin/build --help
 ```
+
+## Configuration
+
+This script will attempt to source a `build.config` file located in either a `.ci` or `ci` directory.
+
+| Options                | Description                                                                                                         |
+|------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `BUILD_OS`             | A comma separated list of valid GOOS operating systems to build for when using the --all flag (i.e. "darwin,linux") |
+| `BUILD_ARCH`           | A comma separated list of valid GOARCH architectures to build for when using the --all flag (i.e. "amd64,arm64")    |
+| `SKIP_BUILD`           | A comma separated list of build combinations that should not be built (i.e. "windows-arm,darwin-arm64")             |
+| `GOLANG_BINARY_NAME`   | The binary name that will be used                                                                                   |
+| `GOLANG_LDFLAGS`       | The build LDFLAGS to add. This script supports adding the `VERSION` and `GIT_COMMIT` variables                      |
+| `GOLANG_PACKAGE`       | The go package name (i.e. go module name or github path)                                                            |
+| `GOLANG_VERSION_PKG`   | The location of the version package in the code base. (i.e. internal/version)                                       |
+| `RELEASE_EXTRA_FILES`  | A comma separated list of files to include in the release tarball (i.e. "LICENSE,README.md")                        |
+
+> **Note:** The default `LDFLAGS` that will be used are `-s -w -X main.version=${VERSION} -X main.gitCommit=${GIT_COMMIT}`

--- a/bin/build
+++ b/bin/build
@@ -31,6 +31,9 @@
 # BUILD_ARCH          - A comma separated list of valid GOARCH architectures to build for when using
 #                       the --all flag (i.e. "amd64,arm64").
 # ------------------------------------------------------------------------------------------------------------------------
+# SKIP_BUILD          - A comma separated list of build combinations that should not be built
+#                       (i.e. "windows-arm,darwin-arm64").
+# ------------------------------------------------------------------------------------------------------------------------
 # GOLANG_BINARY_NAME  - The binary name that will be used.
 # ------------------------------------------------------------------------------------------------------------------------
 # GOLANG_LDFLAGS      - The build LDFLAGS to add. This script supports adding the VERSION and GIT_COMMIT variables.
@@ -212,12 +215,17 @@ get_arch() {
 get_build_targets() {
   local build_os=$(echo ${BUILD_OS} | sed 's/,/ /g')
   local build_arch=$(echo ${BUILD_ARCH} | sed 's/,/ /g')
+  local skip_build=$(echo ${SKIP_BUILD} | sed 's/,/\\n/g')
   local build_targets=""
 
   for os in $build_os; do
     for arch in $build_arch; do
       # validate a supported GOOS and GOARCH combination
       if go tool dist list | grep -w ${os}/${arch} > /dev/null ; then
+        # check that this is not a skipped combination
+        if [[ "$(echo -e ${skip_build} | grep ${os}-${arch})" != "" ]]; then
+          continue
+        fi
         # add the combo to the build targets list
         if [[ -z ${build_targets} ]]; then
           build_targets="${os}/${arch}"


### PR DESCRIPTION
This PR add an option to skip a build combination from the given `BUILD_OS` and `BUILD_ARCH` combinations. You can now use `SKIP_BUILD` to configure this feature and the matching `BUILD_OS-BUILD_ARCH` will be skipped when building all binaries.

**Example:**
`SKIP_BUILD="windows-arm,linux-arm"`